### PR TITLE
Removed dependency

### DIFF
--- a/fir_tagartifact/migrations/0001_initial.py
+++ b/fir_tagartifact/migrations/0001_initial.py
@@ -6,9 +6,9 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('incidents', '0005_auto_20150525_1551'),
-    ]
+#    dependencies = [
+#        ('incidents', '0005_auto_20150525_1551'),
+#    ]
 
     operations = [
         migrations.CreateModel(


### PR DESCRIPTION
Removed dependency to resolve missing migration on last FIR version 
(solves Error message when doing migration:  django.db.migrations.exceptions.NodeNotFoundError: Migration fir_tagartifact.0001_initial dependencies reference nonexistent parent node (u'incidents', u'0005_auto_20150525_1551'))
